### PR TITLE
Bedre setting av kontor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 22
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 21
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
           gradle-version: "8.13"
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - name: ao-oppfolgingskontor - Generate graphql schema
+        run: ./gradlew graphqlGenerateSDL
+
       - name: ao-oppfolgingskontor - Test and build
         run: ./gradlew build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 22
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 22
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: ao-oppfolgingskontor - Generate graphql schema
-        run: ./gradlew graphqlGenerateSDL
+        run: ./gradlew graphqlGenerateSDL --rerun-tasks
 
       - name: ao-oppfolgingskontor - Test and build
         run: ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,10 +84,6 @@ graphql {
     }
 }
 
-tasks.build {
-    dependsOn(tasks.compileKotlin)
-}
-
 tasks.jacocoTestReport {
     dependsOn(tasks.test)
     reports {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,10 @@ graphql {
     }
 }
 
+tasks.build {
+    dependsOn(tasks.graphqlGenerateSDL)
+}
+
 tasks.jacocoTestReport {
     dependsOn(tasks.test)
     reports {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,12 +23,12 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
 kotlin {
-    jvmToolchain(22)
+    jvmToolchain(21)
 }
 
 tasks.shadowJar {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ graphql {
 }
 
 tasks.build {
-    dependsOn(tasks.graphqlGenerateSDL)
+    dependsOn(tasks.compileKotlin)
 }
 
 tasks.jacocoTestReport {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,12 +23,12 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(22)
 }
 
 tasks.shadowJar {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ hikari-version = "6.3.0"
 logstash-version = "8.0"
 embedded-postgres-version = "2.1.0"
 kotest-version = "5.9.1"
-graphql-kotlin-version = "8.7.0"
+graphql-kotlin-version = "8.5.0"
 token-validation-ktor-v3-version = "5.0.24"
 mock-oauth2-server-version = "2.1.10"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ hikari-version = "6.3.0"
 logstash-version = "8.0"
 embedded-postgres-version = "2.1.0"
 kotest-version = "5.9.1"
-graphql-kotlin-version = "8.5.0"
+graphql-kotlin-version = "8.7.0"
 token-validation-ktor-v3-version = "5.0.24"
 mock-oauth2-server-version = "2.1.10"
 

--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -1,9 +1,6 @@
 package no.nav
 
-import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.*
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import kotlinx.serialization.json.Json
 import no.nav.db.configureDatabase
 import no.nav.http.client.Norg2Client
 import no.nav.http.configureArbeidsoppfolgingskontorModule
@@ -17,19 +14,9 @@ fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
 }
 
-fun Application.configureContentNegotiation() {
-    install(ContentNegotiation) {
-        json(Json {
-            ignoreUnknownKeys = true
-            explicitNulls = false // Missing fields will be null
-        })
-    }
-}
-
 fun Application.module() {
-    configureContentNegotiation()
     configureMonitoring()
-    configureHTTP()
+    configureHealthAndCompression()
     configureSecurity()
     configureDatabase()
     install(KafkaStreamsPlugin)

--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -5,9 +5,13 @@ import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import kotlinx.serialization.json.Json
 import no.nav.db.configureDatabase
+import no.nav.http.client.Norg2Client
 import no.nav.http.configureArbeidsoppfolgingskontorModule
 import no.nav.http.graphql.configureGraphQlModule
+import no.nav.http.graphql.getNorg2Url
 import no.nav.kafka.KafkaStreamsPlugin
+import no.nav.services.KontorNavnService
+import no.nav.services.KontorTilhorighetService
 
 fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
@@ -23,11 +27,15 @@ fun Application.configureContentNegotiation() {
 }
 
 fun Application.module() {
+    configureContentNegotiation()
     configureMonitoring()
     configureHTTP()
     configureSecurity()
     configureDatabase()
     install(KafkaStreamsPlugin)
-    configureGraphQlModule()
-    configureArbeidsoppfolgingskontorModule()
+    val norg2Client = Norg2Client(environment.getNorg2Url())
+    val kontorNavnService = KontorNavnService(norg2Client)
+    val kontorTilhorighetService = KontorTilhorighetService(kontorNavnService)
+    configureGraphQlModule(norg2Client, kontorTilhorighetService)
+    configureArbeidsoppfolgingskontorModule(kontorNavnService, KontorTilhorighetService(kontorNavnService))
 }

--- a/src/main/kotlin/HTTP.kt
+++ b/src/main/kotlin/HTTP.kt
@@ -5,7 +5,7 @@ import io.ktor.server.application.*
 import io.ktor.server.plugins.compression.*
 import io.ktor.server.routing.routing
 
-fun Application.configureHTTP() {
+fun Application.configureHealthAndCompression() {
     install(Compression)
     routing {
         healthEndpoints()

--- a/src/main/kotlin/db/KontorRepo.kt
+++ b/src/main/kotlin/db/KontorRepo.kt
@@ -2,8 +2,8 @@ package no.nav.db
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import no.nav.db.dto.ArbeidsoppfolgingKontor
-import no.nav.db.dto.ArenaKontor
+import no.nav.db.dto.ArbeidsoppfolgingDBKontor
+import no.nav.db.dto.ArenaDBKontor
 import no.nav.db.dto.toArbeidsoppfolgingKontor
 import no.nav.db.dto.toArenaKontor
 import no.nav.db.entity.ArbeidsOppfolgingKontorEntity
@@ -32,7 +32,7 @@ class KontorRepo(val dataSource: DataSource) {
 
 data class KontorTilhorighet(
     val fnr: Fnr,
-    val arenaKontor: ArenaKontor?,
-    val arbeidsoppfolgingKontor: ArbeidsoppfolgingKontor?,
+    val arenaKontor: ArenaDBKontor?,
+    val arbeidsoppfolgingKontor: ArbeidsoppfolgingDBKontor?,
 )
 

--- a/src/main/kotlin/db/dto/ArbeidsoppfolgingsDBKontor.kt
+++ b/src/main/kotlin/db/dto/ArbeidsoppfolgingsDBKontor.kt
@@ -3,13 +3,13 @@ package no.nav.db.dto
 import no.nav.db.entity.ArbeidsOppfolgingKontorEntity
 
 
-class ArbeidsoppfolgingKontor(
+class ArbeidsoppfolgingDBKontor(
     kontorId: String,
     metadata: KontorMetadata,
-): Kontor(kontorId, metadata)
+): DBKontor(kontorId, metadata)
 
-fun ArbeidsOppfolgingKontorEntity.toArbeidsoppfolgingKontor(): ArbeidsoppfolgingKontor {
-    return ArbeidsoppfolgingKontor(
+fun ArbeidsOppfolgingKontorEntity.toArbeidsoppfolgingKontor(): ArbeidsoppfolgingDBKontor {
+    return ArbeidsoppfolgingDBKontor(
         kontorId = this.kontorId,
         metadata = KontorMetadata(
             createdAt = this.createdAt,

--- a/src/main/kotlin/db/dto/ArenaDBKontor.kt
+++ b/src/main/kotlin/db/dto/ArenaDBKontor.kt
@@ -2,13 +2,13 @@ package no.nav.db.dto
 
 import no.nav.db.entity.ArenaKontorEntity
 
-class ArenaKontor (
+class ArenaDBKontor (
     kontorId: String,
     metadata: KontorMetadata,
-): Kontor(kontorId, metadata)
+): DBKontor(kontorId, metadata)
 
-fun ArenaKontorEntity.toArenaKontor(): ArenaKontor {
-    return ArenaKontor(
+fun ArenaKontorEntity.toArenaKontor(): ArenaDBKontor {
+    return ArenaDBKontor(
         kontorId = this.kontorId,
         metadata = KontorMetadata(
             createdAt = this.createdAt,

--- a/src/main/kotlin/db/dto/DBKontor.kt
+++ b/src/main/kotlin/db/dto/DBKontor.kt
@@ -2,7 +2,8 @@ package no.nav.db.dto
 
 import java.time.OffsetDateTime
 
-sealed class Kontor(
+/* Data carrier from DB to services or controllers. Not dto exposed through http-APIs */
+sealed class DBKontor(
     val kontorId: String,
     val metadata: KontorMetadata
 )

--- a/src/main/kotlin/db/entity/ArbeidsOppfolgingKontorEntity.kt
+++ b/src/main/kotlin/db/entity/ArbeidsOppfolgingKontorEntity.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.id.EntityID
 
-class ArbeidsOppfolgingKontorEntity(id: EntityID<String>): Entity<String>(id) {
+class ArbeidsOppfolgingKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
     companion object : ImmutableEntityClass<String, ArbeidsOppfolgingKontorEntity>(ArbeidsOppfolgingKontorTable)
     val fnr by ArbeidsOppfolgingKontorTable.id
     val kontorId by ArbeidsOppfolgingKontorTable.kontorId

--- a/src/main/kotlin/db/entity/ArbeidsOppfolgingKontorEntity.kt
+++ b/src/main/kotlin/db/entity/ArbeidsOppfolgingKontorEntity.kt
@@ -1,12 +1,13 @@
 package no.nav.db.entity
 
 import no.nav.db.table.ArbeidsOppfolgingKontorTable
+import no.nav.domain.KontorId
 import org.jetbrains.exposed.dao.Entity
 import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.id.EntityID
 
-class ArbeidsOppfolgingKontorEntity(id: EntityID<String>): Entity<String>(id) {
+class ArbeidsOppfolgingKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
     companion object : ImmutableEntityClass<String, ArbeidsOppfolgingKontorEntity>(ArbeidsOppfolgingKontorTable)
     val fnr by ArbeidsOppfolgingKontorTable.id
     val kontorId by ArbeidsOppfolgingKontorTable.kontorId
@@ -14,4 +15,8 @@ class ArbeidsOppfolgingKontorEntity(id: EntityID<String>): Entity<String>(id) {
     val endretAvType by ArbeidsOppfolgingKontorTable.endretAvType
     val createdAt by ArbeidsOppfolgingKontorTable.createdAt
     val updatedAt by ArbeidsOppfolgingKontorTable.updatedAt
+
+    override fun getKontorId(): KontorId {
+        return KontorId(kontorId)
+    }
 }

--- a/src/main/kotlin/db/entity/ArbeidsOppfolgingKontorEntity.kt
+++ b/src/main/kotlin/db/entity/ArbeidsOppfolgingKontorEntity.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.id.EntityID
 
-class ArbeidsOppfolgingKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
+class ArbeidsOppfolgingKontorEntity(id: EntityID<String>): Entity<String>(id) {
     companion object : ImmutableEntityClass<String, ArbeidsOppfolgingKontorEntity>(ArbeidsOppfolgingKontorTable)
     val fnr by ArbeidsOppfolgingKontorTable.id
     val kontorId by ArbeidsOppfolgingKontorTable.kontorId

--- a/src/main/kotlin/db/entity/ArenaKontorEntity.kt
+++ b/src/main/kotlin/db/entity/ArenaKontorEntity.kt
@@ -1,15 +1,20 @@
 package no.nav.db.entity
 
 import no.nav.db.table.ArenaKontorTable
+import no.nav.domain.KontorId
 import org.jetbrains.exposed.dao.Entity
 import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 
-class ArenaKontorEntity(id: EntityID<String>): Entity<String>(id) {
+class ArenaKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
     companion object : ImmutableEntityClass<String, ArenaKontorEntity>(ArenaKontorTable)
     val fnr by ArenaKontorTable.id
     val kontorId by ArenaKontorTable.kontorId
     val createdAt by ArenaKontorTable.createdAt
     val updatedAt by ArenaKontorTable.updatedAt
     val sistEndretDatoArena by ArenaKontorTable.sistEndretDatoArena
+
+    override fun getKontorId(): KontorId {
+        return KontorId(kontorId)
+    }
 }

--- a/src/main/kotlin/db/entity/ArenaKontorEntity.kt
+++ b/src/main/kotlin/db/entity/ArenaKontorEntity.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.dao.Entity
 import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 
-class ArenaKontorEntity(id: EntityID<String>): Entity<String>(id) {
+class ArenaKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
     companion object : ImmutableEntityClass<String, ArenaKontorEntity>(ArenaKontorTable)
     val fnr by ArenaKontorTable.id
     val kontorId by ArenaKontorTable.kontorId

--- a/src/main/kotlin/db/entity/ArenaKontorEntity.kt
+++ b/src/main/kotlin/db/entity/ArenaKontorEntity.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.dao.Entity
 import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 
-class ArenaKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
+class ArenaKontorEntity(id: EntityID<String>): Entity<String>(id) {
     companion object : ImmutableEntityClass<String, ArenaKontorEntity>(ArenaKontorTable)
     val fnr by ArenaKontorTable.id
     val kontorId by ArenaKontorTable.kontorId

--- a/src/main/kotlin/db/entity/GeografiskTilknyttetKontorEntity.kt
+++ b/src/main/kotlin/db/entity/GeografiskTilknyttetKontorEntity.kt
@@ -1,14 +1,19 @@
 package no.nav.db.entity
 
 import no.nav.db.table.GeografiskTilknytningKontorTable
+import no.nav.domain.KontorId
 import org.jetbrains.exposed.dao.Entity
 import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 
-class GeografiskTilknyttetKontorEntity(id: EntityID<String>): Entity<String>(id) {
+class GeografiskTilknyttetKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
     companion object : ImmutableEntityClass<String, GeografiskTilknyttetKontorEntity>(GeografiskTilknytningKontorTable)
     val fnr by GeografiskTilknytningKontorTable.id
     val kontorId by GeografiskTilknytningKontorTable.kontorId
     val createdAt by GeografiskTilknytningKontorTable.createdAt
     val updatedAt by GeografiskTilknytningKontorTable.updatedAt
+
+    override fun getKontorId(): KontorId {
+        return KontorId(kontorId)
+    }
 }

--- a/src/main/kotlin/db/entity/GeografiskTilknyttetKontorEntity.kt
+++ b/src/main/kotlin/db/entity/GeografiskTilknyttetKontorEntity.kt
@@ -1,0 +1,14 @@
+package no.nav.db.entity
+
+import no.nav.db.table.GeografiskTilknytningKontorTable
+import org.jetbrains.exposed.dao.Entity
+import org.jetbrains.exposed.dao.ImmutableEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+
+class GeografiskTilknyttetKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
+    companion object : ImmutableEntityClass<String, GeografiskTilknyttetKontorEntity>(GeografiskTilknytningKontorTable)
+    val fnr by GeografiskTilknytningKontorTable.id
+    val kontorId by GeografiskTilknytningKontorTable.kontorId
+    val createdAt by GeografiskTilknytningKontorTable.createdAt
+    val updatedAt by GeografiskTilknytningKontorTable.updatedAt
+}

--- a/src/main/kotlin/db/entity/GeografiskTilknyttetKontorEntity.kt
+++ b/src/main/kotlin/db/entity/GeografiskTilknyttetKontorEntity.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.dao.Entity
 import org.jetbrains.exposed.dao.ImmutableEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 
-class GeografiskTilknyttetKontorEntity(id: EntityID<String>): Entity<String>(id), KontorEntity {
+class GeografiskTilknyttetKontorEntity(id: EntityID<String>): Entity<String>(id) {
     companion object : ImmutableEntityClass<String, GeografiskTilknyttetKontorEntity>(GeografiskTilknytningKontorTable)
     val fnr by GeografiskTilknytningKontorTable.id
     val kontorId by GeografiskTilknytningKontorTable.kontorId

--- a/src/main/kotlin/db/entity/KontorEntity.kt
+++ b/src/main/kotlin/db/entity/KontorEntity.kt
@@ -1,0 +1,3 @@
+package no.nav.db.entity
+
+sealed interface KontorEntity

--- a/src/main/kotlin/db/entity/KontorEntity.kt
+++ b/src/main/kotlin/db/entity/KontorEntity.kt
@@ -1,3 +1,7 @@
 package no.nav.db.entity
 
-sealed interface KontorEntity
+import no.nav.domain.KontorId
+
+sealed interface KontorEntity {
+    fun getKontorId(): KontorId
+}

--- a/src/main/kotlin/domain/Kontor.kt
+++ b/src/main/kotlin/domain/Kontor.kt
@@ -9,3 +9,13 @@ class ArbeidsoppfolgingsKontor(
     kontorNavn: KontorNavn,
     kontorId: KontorId
 ): Kontor(kontorNavn, kontorId)
+
+class ArenaKontor(
+    kontorNavn: KontorNavn,
+    kontorId: KontorId
+): Kontor(kontorNavn, kontorId)
+
+class GeografiskTilknyttetKontor(
+    kontorNavn: KontorNavn,
+    kontorId: KontorId
+): Kontor(kontorNavn, kontorId)

--- a/src/main/kotlin/domain/Kontor.kt
+++ b/src/main/kotlin/domain/Kontor.kt
@@ -1,0 +1,11 @@
+package no.nav.domain
+
+sealed class Kontor(
+    val kontorNavn: KontorNavn,
+    val kontorId: KontorId
+)
+
+class ArbeidsoppfolgingsKontor(
+    kontorNavn: KontorNavn,
+    kontorId: KontorId
+): Kontor(kontorNavn, kontorId)

--- a/src/main/kotlin/domain/KontorId.kt
+++ b/src/main/kotlin/domain/KontorId.kt
@@ -1,0 +1,5 @@
+package no.nav.domain
+
+data class KontorId(
+    val id: String,
+)

--- a/src/main/kotlin/domain/KontorNavn.kt
+++ b/src/main/kotlin/domain/KontorNavn.kt
@@ -1,0 +1,5 @@
+package no.nav.domain
+
+data class KontorNavn(
+    val navn: String,
+)

--- a/src/main/kotlin/http/SetArbeidsoppfolgingskontorModule.kt
+++ b/src/main/kotlin/http/SetArbeidsoppfolgingskontorModule.kt
@@ -9,6 +9,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import no.nav.db.Fnr
 import no.nav.db.table.ArbeidsOppfolgingKontorTable
 import no.nav.db.table.KontorhistorikkTable.fnr
@@ -24,7 +25,10 @@ fun Application.configureArbeidsoppfolgingskontorModule() {
 
     routing {
         install(ContentNegotiation) {
-            json()
+            json(Json {
+                ignoreUnknownKeys = true
+                explicitNulls = false
+            })
         }
         authenticate {
             post("/api/kontor") {

--- a/src/main/kotlin/http/SetArbeidsoppfolgingskontorModule.kt
+++ b/src/main/kotlin/http/SetArbeidsoppfolgingskontorModule.kt
@@ -56,7 +56,7 @@ fun Application.configureArbeidsoppfolgingskontorModule(
                     }.let { KontorId(it[ArbeidsOppfolgingKontorTable.kontorId]) to gammeltKontor }
                 }
                     .onSuccess { (kontorId, gammeltKontor) ->
-                        val kontor = kontorNavnService.getKontorNavn(kontorId)
+                        val kontorNavn = kontorNavnService.getKontorNavn(kontorId)
                         call.respond(KontorByttetOkResponseDto(
                             fraKontor = gammeltKontor?.let {
                                 Kontor(
@@ -65,8 +65,8 @@ fun Application.configureArbeidsoppfolgingskontorModule(
                                 )
                             },
                             tilKontor = Kontor(
-                                kontorNavn = kontor.kontorNavn.navn,
-                                kontorId = kontor.kontorId.id
+                                kontorNavn = kontorNavn.navn,
+                                kontorId = kontorId.id
                             )
                         ))
                         call.respondText("OK", status = HttpStatusCode.OK)

--- a/src/main/kotlin/http/client/Norg2Client.kt
+++ b/src/main/kotlin/http/client/Norg2Client.kt
@@ -32,7 +32,7 @@ class Norg2Client(
         }
         return response.body<List<NorgKontor>>()
             .filter { it.type == "LOKAL" }
-            .map { MinimaltNorgKontor(it.enhetNr, it.navn) }
+            .map { it.toMinimaltKontor() }
     }
 
     suspend fun hentKontor(kontorId: KontorId): MinimaltNorgKontor {
@@ -41,8 +41,7 @@ class Norg2Client(
         }
         if (response.status != HttpStatusCode.OK)
             throw RuntimeException("Kunne ikke hente kontor med id $kontorId fra Norg2. Status: ${response.status}")
-        return response.body<NorgKontor>()
-            .let { MinimaltNorgKontor(it.enhetNr, it.navn) }
+        return response.body<NorgKontor>().toMinimaltKontor()
     }
 
     companion object {
@@ -55,6 +54,11 @@ class Norg2Client(
 data class MinimaltNorgKontor(
     val kontorId: String,
     val navn: String
+)
+
+fun NorgKontor.toMinimaltKontor() = MinimaltNorgKontor(
+    kontorId = this.enhetNr,
+    navn = this.navn
 )
 
 @Serializable

--- a/src/main/kotlin/http/graphql/GraphqlModule.kt
+++ b/src/main/kotlin/http/graphql/GraphqlModule.kt
@@ -15,8 +15,9 @@ import no.nav.http.client.Norg2Client
 import no.nav.http.graphql.queries.AlleKontorQuery
 import no.nav.http.graphql.queries.KontorHistorikkQuery
 import no.nav.http.graphql.queries.KontorQuery
+import no.nav.services.KontorTilhorighetService
 
-fun Application.installGraphQl(norg2Client: Norg2Client) {
+fun Application.installGraphQl(norg2Client: Norg2Client, kontorTilhorighetService: KontorTilhorighetService) {
     install(GraphQL) {
         schema {
             packages = listOf(
@@ -24,7 +25,7 @@ fun Application.installGraphQl(norg2Client: Norg2Client) {
                 "no.nav.http.graphql.queries",
             )
             queries = listOf(
-                KontorQuery(),
+                KontorQuery(kontorTilhorighetService),
                 KontorHistorikkQuery(),
                 AlleKontorQuery(norg2Client)
             )
@@ -36,10 +37,8 @@ fun ApplicationEnvironment.getNorg2Url(): String {
     return config.property("apis.norg2.url").getString()
 }
 
-fun Application.configureGraphQlModule() {
-    val norg2Client = Norg2Client(environment.getNorg2Url())
-
-    installGraphQl(norg2Client)
+fun Application.configureGraphQlModule(norg2Client: Norg2Client, kontorTilhorighetService: KontorTilhorighetService) {
+    installGraphQl(norg2Client, kontorTilhorighetService)
 
     routing {
         authenticate {

--- a/src/main/kotlin/http/graphql/queries/KontorHistorikkQuery.kt
+++ b/src/main/kotlin/http/graphql/queries/KontorHistorikkQuery.kt
@@ -14,11 +14,11 @@ import org.slf4j.LoggerFactory
 class KontorHistorikkQuery : Query {
     val logger = LoggerFactory.getLogger(KontorHistorikkQuery::class.java)
 
-    fun kontorHistorikk(fnrParam: String, dataFetchingEnvironment: DataFetchingEnvironment): List<KontorHistorikkQueryDto> {
+    fun kontorHistorikk(fnr: String, dataFetchingEnvironment: DataFetchingEnvironment): List<KontorHistorikkQueryDto> {
         return runCatching {
             transaction {
                 KontorHistorikkEntity
-                    .find { KontorhistorikkTable.fnr eq fnrParam }
+                    .find { KontorhistorikkTable.fnr eq fnr }
                     .orderBy(KontorhistorikkTable.id to SortOrder.ASC)
                     .map {
                         val endringsType = KontorEndringsType.valueOf(it.kontorendringstype)
@@ -34,7 +34,7 @@ class KontorHistorikkQuery : Query {
             }
         }
             .onFailure {
-                logger.error("Feil ved henting av kontorhistorikk for fnr: $fnrParam", it)
+                logger.error("Feil ved henting av kontorhistorikk")
                 throw it
             }
             .onSuccess { return it }

--- a/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
+++ b/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
@@ -3,16 +3,13 @@ package no.nav.http.graphql.queries
 import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.nav.db.Fnr
-import no.nav.db.table.ArbeidsOppfolgingKontorTable
-import no.nav.domain.KontorKilde
 import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
 import no.nav.services.KontorTilhorighetService
-import org.jetbrains.exposed.sql.*
 
 class KontorQuery(
     val kontorTilhorighetService: KontorTilhorighetService
 ) : Query {
-    suspend fun kontorTilhorighet(fnrParam: Fnr, dataFetchingEnvironment: DataFetchingEnvironment): KontorTilhorighetQueryDto? {
-        return kontorTilhorighetService.getKontorTilhorighet(fnrParam)
+    suspend fun kontorTilhorighet(fnr: Fnr, dataFetchingEnvironment: DataFetchingEnvironment): KontorTilhorighetQueryDto? {
+        return kontorTilhorighetService.getKontorTilhorighet(fnr)
     }
 }

--- a/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
+++ b/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
@@ -4,52 +4,19 @@ import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.nav.db.Fnr
 import no.nav.db.table.ArbeidsOppfolgingKontorTable
-import no.nav.db.table.ArenaKontorTable
-import no.nav.db.table.GeografiskTilknytningKontorTable
 import no.nav.domain.KontorKilde
 import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
+import no.nav.services.KontorTilhorighetService
 import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.transactions.transaction
 
 val kontorAlias = ArbeidsOppfolgingKontorTable.kontorId.alias("kontorid")
 val kontorkildeAlias = stringLiteral(KontorKilde.ARBEIDSOPPFOLGING.name).alias("kilde") // Tilfeldig valgt verdi
 val prioritetAlias = intLiteral(0).alias("prioritet")
 
-class KontorQuery : Query {
+class KontorQuery(
+    val kontorTilhorighetService: KontorTilhorighetService
+) : Query {
     fun kontorTilhorighet(fnrParam: Fnr, dataFetchingEnvironment: DataFetchingEnvironment): KontorTilhorighetQueryDto? {
-        return transaction {
-
-            val arbeidsoppfolgingKontorQuery = ArbeidsOppfolgingKontorTable.select(
-                ArbeidsOppfolgingKontorTable.kontorId.alias(kontorAlias.alias),
-                stringLiteral(KontorKilde.ARBEIDSOPPFOLGING.name).alias(kontorkildeAlias.alias),
-                intLiteral(1).alias(prioritetAlias.alias)
-            )
-                .where { ArbeidsOppfolgingKontorTable.id eq fnrParam }
-
-            val arenaKontorQuery = ArenaKontorTable.select(
-                ArenaKontorTable.kontorId.alias(kontorAlias.alias),
-                stringLiteral(KontorKilde.ARENA.name).alias(kontorkildeAlias.alias),
-                intLiteral(2).alias(prioritetAlias.alias)
-            )
-                .where { ArenaKontorTable.id eq fnrParam }
-
-            val geografiskTilknytningKontorQuery =
-                GeografiskTilknytningKontorTable.select(
-                    GeografiskTilknytningKontorTable.kontorId.alias(kontorAlias.alias),
-                    stringLiteral(KontorKilde.GEOGRAFISK_TILKNYTNING.name).alias(kontorkildeAlias.alias),
-                    intLiteral(3).alias(prioritetAlias.alias)
-                )
-                    .where(GeografiskTilknytningKontorTable.id eq fnrParam)
-
-            val resultRow = arbeidsoppfolgingKontorQuery
-                .unionAll(arenaKontorQuery)
-                .unionAll(geografiskTilknytningKontorQuery)
-                .orderBy(prioritetAlias to SortOrder.ASC)
-                .limit(1)
-                .firstOrNull()
-
-            resultRow?.let { row -> KontorTilhorighetQueryDto(row[kontorAlias], KontorKilde.valueOf(row[kontorkildeAlias])) }
-        }
+        return kontorTilhorighetService.getKontorTilhorighet(fnrParam)
     }
 }

--- a/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
+++ b/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
@@ -9,14 +9,10 @@ import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
 import no.nav.services.KontorTilhorighetService
 import org.jetbrains.exposed.sql.*
 
-val kontorAlias = ArbeidsOppfolgingKontorTable.kontorId.alias("kontorid")
-val kontorkildeAlias = stringLiteral(KontorKilde.ARBEIDSOPPFOLGING.name).alias("kilde") // Tilfeldig valgt verdi
-val prioritetAlias = intLiteral(0).alias("prioritet")
-
 class KontorQuery(
     val kontorTilhorighetService: KontorTilhorighetService
 ) : Query {
-    fun kontorTilhorighet(fnrParam: Fnr, dataFetchingEnvironment: DataFetchingEnvironment): KontorTilhorighetQueryDto? {
+    suspend fun kontorTilhorighet(fnrParam: Fnr, dataFetchingEnvironment: DataFetchingEnvironment): KontorTilhorighetQueryDto? {
         return kontorTilhorighetService.getKontorTilhorighet(fnrParam)
     }
 }

--- a/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
+++ b/src/main/kotlin/http/graphql/queries/KontorTilhorighetQuery.kt
@@ -4,12 +4,25 @@ import com.expediagroup.graphql.server.operations.Query
 import graphql.schema.DataFetchingEnvironment
 import no.nav.db.Fnr
 import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
+import no.nav.http.graphql.schemas.KontorTilhorigheterQueryDto
+import no.nav.http.graphql.schemas.toArbeidsoppfolgingKontorDto
+import no.nav.http.graphql.schemas.toArenaKontorDto
+import no.nav.http.graphql.schemas.toGeografiskTilknyttetKontorDto
 import no.nav.services.KontorTilhorighetService
 
 class KontorQuery(
     val kontorTilhorighetService: KontorTilhorighetService
 ) : Query {
+
     suspend fun kontorTilhorighet(fnr: Fnr, dataFetchingEnvironment: DataFetchingEnvironment): KontorTilhorighetQueryDto? {
         return kontorTilhorighetService.getKontorTilhorighet(fnr)
+    }
+
+    suspend fun kontorTilhorigheter(fnr: Fnr, dataFetchingEnvironment: DataFetchingEnvironment): KontorTilhorigheterQueryDto {
+        return KontorTilhorigheterQueryDto(
+            arena = kontorTilhorighetService.getArenaKontorTilhorighet(fnr)?.toArenaKontorDto(),
+            geografiskTilknytning = kontorTilhorighetService.getGeografiskTilknyttetKontorTilhorighet(fnr)?.toGeografiskTilknyttetKontorDto(),
+            arbeidsoppfolging = kontorTilhorighetService.getArbeidsoppfolgingKontorTilhorighet(fnr)?.toArbeidsoppfolgingKontorDto(),
+        )
     }
 }

--- a/src/main/kotlin/http/graphql/schemas/AlleKontorQueryDto.kt
+++ b/src/main/kotlin/http/graphql/schemas/AlleKontorQueryDto.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AlleKontorQueryDto(
     val kontorId: String,
-    val navn: String,
+    val kontorNavn: String,
 )

--- a/src/main/kotlin/http/graphql/schemas/KontorTilhorighetQueryDto.kt
+++ b/src/main/kotlin/http/graphql/schemas/KontorTilhorighetQueryDto.kt
@@ -7,4 +7,12 @@ import no.nav.domain.KontorKilde
 data class KontorTilhorighetQueryDto(
     val kontorId: String,
     val kilde: KontorKilde,
+    val registrant: String,
+    val registrantType: RegistrantTypeDto
 )
+
+enum class RegistrantTypeDto {
+    ARENA, // I arena settes kontor noen ganger av veileder og noen ganger av system men det er vanskelig å se hvilken
+    VEILEDER,
+    SYSTEM, // Automatiske kontorsettinger, feks ved arbeidssøkerregistrering, endring i adressebeskyttelse eller skjermingstatus
+}

--- a/src/main/kotlin/http/graphql/schemas/KontorTilhorighetQueryDto.kt
+++ b/src/main/kotlin/http/graphql/schemas/KontorTilhorighetQueryDto.kt
@@ -6,6 +6,7 @@ import no.nav.domain.KontorKilde
 @Serializable
 data class KontorTilhorighetQueryDto(
     val kontorId: String,
+    val kontorNavn: String,
     val kilde: KontorKilde,
     val registrant: String,
     val registrantType: RegistrantTypeDto

--- a/src/main/kotlin/http/graphql/schemas/KontorTilhorigheterQueryDto.kt
+++ b/src/main/kotlin/http/graphql/schemas/KontorTilhorigheterQueryDto.kt
@@ -1,0 +1,44 @@
+package no.nav.http.graphql.schemas
+
+import kotlinx.serialization.Serializable
+import no.nav.domain.ArbeidsoppfolgingsKontor
+import no.nav.domain.ArenaKontor
+import no.nav.domain.GeografiskTilknyttetKontor
+
+@Serializable
+data class KontorTilhorigheterQueryDto(
+    val arena: ArenaKontorDto?,
+    val geografiskTilknytning: GeografiskTilknyttetKontorDto?,
+    val arbeidsoppfolging: ArbeidsoppfolgingKontorDto?,
+)
+
+@Serializable
+data class ArenaKontorDto(
+    val kontorId: String,
+    val kontorNavn: String,
+)
+fun ArenaKontor.toArenaKontorDto() = ArenaKontorDto(
+    kontorId = this.kontorId.id,
+    kontorNavn = this.kontorNavn.navn,
+)
+
+@Serializable
+data class GeografiskTilknyttetKontorDto(
+    val kontorId: String,
+    val kontorNavn: String,
+)
+fun GeografiskTilknyttetKontor.toGeografiskTilknyttetKontorDto() = GeografiskTilknyttetKontorDto(
+    kontorId = this.kontorId.id,
+    kontorNavn = this.kontorNavn.navn,
+)
+
+@Serializable
+data class ArbeidsoppfolgingKontorDto(
+    val kontorId: String,
+    val kontorNavn: String,
+)
+fun ArbeidsoppfolgingsKontor.toArbeidsoppfolgingKontorDto() = ArbeidsoppfolgingKontorDto(
+    kontorId = this.kontorId.id,
+    kontorNavn = this.kontorNavn.navn,
+)
+

--- a/src/main/kotlin/services/KontorNavnService.kt
+++ b/src/main/kotlin/services/KontorNavnService.kt
@@ -1,0 +1,21 @@
+package no.nav.services
+
+import no.nav.domain.ArbeidsoppfolgingsKontor
+import no.nav.domain.KontorId
+import no.nav.domain.KontorNavn
+import no.nav.http.client.Norg2Client
+
+class KontorNavnService(
+    val norg2Client: Norg2Client
+) {
+    // Skal på et senere tidspunkt cache alle navn i en tabell men foreløpig bare henter vi den fra Norg løpende
+    suspend fun getKontorNavn(kontorId: KontorId): ArbeidsoppfolgingsKontor {
+        return norg2Client.hentKontor(kontorId)
+            .let {
+                ArbeidsoppfolgingsKontor(
+                    kontorNavn = KontorNavn(it.navn),
+                    kontorId = KontorId(it.kontorId)
+                )
+            }
+    }
+}

--- a/src/main/kotlin/services/KontorNavnService.kt
+++ b/src/main/kotlin/services/KontorNavnService.kt
@@ -1,6 +1,5 @@
 package no.nav.services
 
-import no.nav.domain.ArbeidsoppfolgingsKontor
 import no.nav.domain.KontorId
 import no.nav.domain.KontorNavn
 import no.nav.http.client.Norg2Client
@@ -9,13 +8,7 @@ class KontorNavnService(
     val norg2Client: Norg2Client
 ) {
     // Skal på et senere tidspunkt cache alle navn i en tabell men foreløpig bare henter vi den fra Norg løpende
-    suspend fun getKontorNavn(kontorId: KontorId): ArbeidsoppfolgingsKontor {
-        return norg2Client.hentKontor(kontorId)
-            .let {
-                ArbeidsoppfolgingsKontor(
-                    kontorNavn = KontorNavn(it.navn),
-                    kontorId = KontorId(it.kontorId)
-                )
-            }
+    suspend fun getKontorNavn(kontorId: KontorId): KontorNavn {
+        return KontorNavn(norg2Client.hentKontor(kontorId).navn)
     }
 }

--- a/src/main/kotlin/services/KontorTilhorighetService.kt
+++ b/src/main/kotlin/services/KontorTilhorighetService.kt
@@ -17,23 +17,23 @@ import no.nav.domain.KontorId
 import no.nav.domain.KontorKilde
 import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
 import no.nav.http.graphql.schemas.RegistrantTypeDto
-import no.nav.http.logger
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.transactions.transaction
 
 class KontorTilhorighetService(
     val kontorNavnService: KontorNavnService
 ) {
     suspend fun getArbeidsoppfolgingKontorTilhorighet(fnr: Fnr): ArbeidsoppfolgingsKontor? {
-        return newSuspendedTransaction {
+        return transaction {
             ArbeidsOppfolgingKontorEntity.findById(fnr)
-                ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
-                ?.let {
-                    ArbeidsoppfolgingsKontor(
-                        it.kontorNavn,
-                        it.kontorId,
-                    )
-                }
         }
+            ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
+            ?.let {
+                ArbeidsoppfolgingsKontor(
+                    it.kontorNavn,
+                    it.kontorId,
+                )
+            }
     }
 
     fun getGTKontor(fnr: Fnr) = GeografiskTilknyttetKontorEntity.findById(fnr)
@@ -49,9 +49,6 @@ class KontorTilhorighetService(
                     async { getGTKontor(fnr) },
                 )
             }
-            logger.info("kontorer liste: ${kontorer.size}")
-            logger.info("kontorer liste: ${kontorer.filterNotNull().size}")
-            logger.info("kontorer liste: ${kontorer}")
             kontorer.firstOrNull { it != null }
                 .let { kontor ->
                     when (kontor) {

--- a/src/main/kotlin/services/KontorTilhorighetService.kt
+++ b/src/main/kotlin/services/KontorTilhorighetService.kt
@@ -1,0 +1,82 @@
+package no.nav.services
+
+import no.nav.db.Fnr
+import no.nav.db.dto.ArbeidsoppfolgingDBKontor
+import no.nav.db.entity.ArbeidsOppfolgingKontorEntity
+import no.nav.db.table.ArbeidsOppfolgingKontorTable
+import no.nav.db.table.ArenaKontorTable
+import no.nav.db.table.GeografiskTilknytningKontorTable
+import no.nav.domain.ArbeidsoppfolgingsKontor
+import no.nav.domain.KontorId
+import no.nav.domain.KontorKilde
+import no.nav.domain.KontorNavn
+import no.nav.http.graphql.queries.kontorAlias
+import no.nav.http.graphql.queries.kontorkildeAlias
+import no.nav.http.graphql.queries.prioritetAlias
+import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.alias
+import org.jetbrains.exposed.sql.intLiteral
+import org.jetbrains.exposed.sql.stringLiteral
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.unionAll
+
+class KontorTilhorighetService(
+    val kontorNavnService: KontorNavnService
+) {
+    suspend fun getArbeidsoppfolgingKontorTilhorighet(fnr: Fnr): ArbeidsoppfolgingsKontor? {
+        return newSuspendedTransaction {
+            ArbeidsOppfolgingKontorEntity.findById(fnr)
+                ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
+                ?.let {
+                    ArbeidsoppfolgingsKontor(
+                        it.kontorNavn,
+                        it.kontorId,
+                    )
+                }
+        }
+    }
+
+    fun getKontorTilhorighet(fnr: Fnr): KontorTilhorighetQueryDto? {
+        return transaction {
+
+            val arbeidsoppfolgingKontorQuery = ArbeidsOppfolgingKontorTable.select(
+                ArbeidsOppfolgingKontorTable.kontorId.alias(kontorAlias.alias),
+                stringLiteral(KontorKilde.ARBEIDSOPPFOLGING.name).alias(kontorkildeAlias.alias),
+                intLiteral(1).alias(prioritetAlias.alias)
+            )
+                .where { ArbeidsOppfolgingKontorTable.id eq fnr }
+
+            val arenaKontorQuery = ArenaKontorTable.select(
+                ArenaKontorTable.kontorId.alias(kontorAlias.alias),
+                stringLiteral(KontorKilde.ARENA.name).alias(kontorkildeAlias.alias),
+                intLiteral(2).alias(prioritetAlias.alias)
+            )
+                .where { ArenaKontorTable.id eq fnr }
+
+            val geografiskTilknytningKontorQuery =
+                GeografiskTilknytningKontorTable.select(
+                    GeografiskTilknytningKontorTable.kontorId.alias(kontorAlias.alias),
+                    stringLiteral(KontorKilde.GEOGRAFISK_TILKNYTNING.name).alias(kontorkildeAlias.alias),
+                    intLiteral(3).alias(prioritetAlias.alias)
+                )
+                    .where(GeografiskTilknytningKontorTable.id eq fnr)
+
+            val resultRow = arbeidsoppfolgingKontorQuery
+                .unionAll(arenaKontorQuery)
+                .unionAll(geografiskTilknytningKontorQuery)
+                .orderBy(prioritetAlias to SortOrder.ASC)
+                .limit(1)
+                .firstOrNull()
+
+            resultRow?.let { row ->
+                KontorTilhorighetQueryDto(
+                row[kontorAlias],
+                KontorKilde.valueOf(row[kontorkildeAlias])
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/services/KontorTilhorighetService.kt
+++ b/src/main/kotlin/services/KontorTilhorighetService.kt
@@ -22,40 +22,34 @@ class KontorTilhorighetService(
     val kontorNavnService: KontorNavnService
 ) {
     suspend fun getArbeidsoppfolgingKontorTilhorighet(fnr: Fnr): ArbeidsoppfolgingsKontor? {
-        return transaction {
-            ArbeidsOppfolgingKontorEntity.findById(fnr)
-        }
-            ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
-            ?.let {
+        return transaction { ArbeidsOppfolgingKontorEntity.findById(fnr) }
+            ?.let { it to kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
+            ?.let { (kontor, kontorNavn) ->
                 ArbeidsoppfolgingsKontor(
-                    it.kontorNavn,
-                    it.kontorId,
+                    kontorNavn,
+                    kontor.getKontorId(),
                 )
             }
     }
 
     suspend fun getArenaKontorTilhorighet(fnr: Fnr): ArenaKontor? {
-        return transaction {
-            ArenaKontorEntity.findById(fnr)
-        }
-            ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
-            ?.let {
+        return transaction { ArenaKontorEntity.findById(fnr) }
+            ?.let { it to kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
+            ?.let { (kontor, kontorNavn) ->
                 ArenaKontor(
-                    it.kontorNavn,
-                    it.kontorId,
+                    kontorNavn,
+                    kontor.getKontorId(),
                 )
             }
     }
 
     suspend fun getGeografiskTilknyttetKontorTilhorighet(fnr: Fnr): GeografiskTilknyttetKontor? {
-        return transaction {
-            GeografiskTilknyttetKontorEntity.findById(fnr)
-        }
-            ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
-            ?.let {
+        return transaction { GeografiskTilknyttetKontorEntity.findById(fnr) }
+            ?.let { it to kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
+            ?.let { (kontor, kontorNavn) ->
                 GeografiskTilknyttetKontor(
-                    it.kontorNavn,
-                    it.kontorId,
+                    kontorNavn,
+                    kontor.getKontorId(),
                 )
             }
     }
@@ -75,15 +69,14 @@ class KontorTilhorighetService(
             }
             kontorer.firstOrNull { it != null }
                 ?.let {
-                    val kontorMedNavn = kontorNavnService.getKontorNavn(it.getKontorId())
-                    it to kontorMedNavn.kontorNavn
+                    val kontorNavn = kontorNavnService.getKontorNavn(it.getKontorId())
+                    it to kontorNavn
                 }
                 ?.let { (kontor, kontorNavn) ->
                     when (kontor) {
                         is ArbeidsOppfolgingKontorEntity -> kontor.toKontorTilhorighetQueryDto(kontorNavn)
                         is ArenaKontorEntity -> kontor.toKontorTilhorighetQueryDto(kontorNavn)
                         is GeografiskTilknyttetKontorEntity -> kontor.toKontorTilhorighetQueryDto(kontorNavn)
-                        else -> null
                     }
                 }
 

--- a/src/main/kotlin/services/KontorTilhorighetService.kt
+++ b/src/main/kotlin/services/KontorTilhorighetService.kt
@@ -8,6 +8,8 @@ import no.nav.db.entity.ArbeidsOppfolgingKontorEntity
 import no.nav.db.entity.ArenaKontorEntity
 import no.nav.db.entity.GeografiskTilknyttetKontorEntity
 import no.nav.domain.ArbeidsoppfolgingsKontor
+import no.nav.domain.ArenaKontor
+import no.nav.domain.GeografiskTilknyttetKontor
 import no.nav.domain.KontorId
 import no.nav.domain.KontorKilde
 import no.nav.domain.KontorNavn
@@ -26,6 +28,32 @@ class KontorTilhorighetService(
             ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
             ?.let {
                 ArbeidsoppfolgingsKontor(
+                    it.kontorNavn,
+                    it.kontorId,
+                )
+            }
+    }
+
+    suspend fun getArenaKontorTilhorighet(fnr: Fnr): ArenaKontor? {
+        return transaction {
+            ArenaKontorEntity.findById(fnr)
+        }
+            ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
+            ?.let {
+                ArenaKontor(
+                    it.kontorNavn,
+                    it.kontorId,
+                )
+            }
+    }
+
+    suspend fun getGeografiskTilknyttetKontorTilhorighet(fnr: Fnr): GeografiskTilknyttetKontor? {
+        return transaction {
+            GeografiskTilknyttetKontorEntity.findById(fnr)
+        }
+            ?.let { kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
+            ?.let {
+                GeografiskTilknyttetKontor(
                     it.kontorNavn,
                     it.kontorId,
                 )

--- a/src/main/kotlin/services/KontorTilhorighetService.kt
+++ b/src/main/kotlin/services/KontorTilhorighetService.kt
@@ -47,8 +47,7 @@ class KontorTilhorighetService(
             }
             kontorer.firstOrNull { it != null }
                 ?.let {
-                    val kontorId = it.id.value
-                    val kontorMedNavn = kontorNavnService.getKontorNavn(KontorId(kontorId))
+                    val kontorMedNavn = kontorNavnService.getKontorNavn(it.getKontorId())
                     it to kontorMedNavn.kontorNavn
                 }
                 ?.let { (kontor, kontorNavn) ->

--- a/src/main/kotlin/services/KontorTilhorighetService.kt
+++ b/src/main/kotlin/services/KontorTilhorighetService.kt
@@ -1,17 +1,12 @@
 package no.nav.services
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.db.Fnr
 import no.nav.db.entity.ArbeidsOppfolgingKontorEntity
 import no.nav.db.entity.ArenaKontorEntity
 import no.nav.db.entity.GeografiskTilknyttetKontorEntity
-import no.nav.db.entity.KontorEntity
-import no.nav.db.table.ArbeidsOppfolgingKontorTable
 import no.nav.domain.ArbeidsoppfolgingsKontor
 import no.nav.domain.KontorId
 import no.nav.domain.KontorKilde
@@ -52,30 +47,37 @@ class KontorTilhorighetService(
             kontorer.firstOrNull { it != null }
                 .let { kontor ->
                     when (kontor) {
-                        is ArbeidsOppfolgingKontorEntity ->
-                            KontorTilhorighetQueryDto(
-                                kontorId = kontor.kontorId,
-                                kilde = KontorKilde.ARBEIDSOPPFOLGING,
-                                registrant = kontor.endretAv,
-                                registrantType = RegistrantTypeDto.valueOf(kontor.endretAvType),
-                            )
-                        is ArenaKontorEntity ->
-                            KontorTilhorighetQueryDto(
-                                kontorId = kontor.kontorId,
-                                kilde = KontorKilde.ARENA,
-                                registrant = "Arena",
-                                registrantType = RegistrantTypeDto.ARENA,
-                            )
-                        is GeografiskTilknyttetKontorEntity ->
-                            KontorTilhorighetQueryDto(
-                                kontorId = kontor.kontorId,
-                                kilde = KontorKilde.GEOGRAFISK_TILKNYTNING,
-                                registrant = "FREG",
-                                registrantType = RegistrantTypeDto.SYSTEM,
-                            )
+                        is ArbeidsOppfolgingKontorEntity -> kontor.toKontorTilhorighetQueryDto()
+                        is ArenaKontorEntity -> kontor.toKontorTilhorighetQueryDto()
+                        is GeografiskTilknyttetKontorEntity -> kontor.toKontorTilhorighetQueryDto()
                         else -> null
                     }
                 }
         }
     }
+}
+
+fun ArbeidsOppfolgingKontorEntity.toKontorTilhorighetQueryDto(): KontorTilhorighetQueryDto {
+    return KontorTilhorighetQueryDto(
+        kontorId = this.kontorId,
+        kilde = KontorKilde.ARBEIDSOPPFOLGING,
+        registrant = this.endretAv,
+        registrantType = RegistrantTypeDto.valueOf(this.endretAvType),
+    )
+}
+fun ArenaKontorEntity.toKontorTilhorighetQueryDto(): KontorTilhorighetQueryDto {
+    return KontorTilhorighetQueryDto(
+        kontorId = this.kontorId,
+        kilde = KontorKilde.ARENA,
+        registrant = "Arena",
+        registrantType = RegistrantTypeDto.ARENA,
+    )
+}
+fun GeografiskTilknyttetKontorEntity.toKontorTilhorighetQueryDto(): KontorTilhorighetQueryDto {
+    return KontorTilhorighetQueryDto(
+        kontorId = this.kontorId,
+        kilde = KontorKilde.GEOGRAFISK_TILKNYTNING,
+        registrant = "FREG",
+        registrantType = RegistrantTypeDto.SYSTEM,
+    )
 }

--- a/src/main/kotlin/services/KontorTilhorighetService.kt
+++ b/src/main/kotlin/services/KontorTilhorighetService.kt
@@ -22,41 +22,26 @@ class KontorTilhorighetService(
     val kontorNavnService: KontorNavnService
 ) {
     suspend fun getArbeidsoppfolgingKontorTilhorighet(fnr: Fnr): ArbeidsoppfolgingsKontor? {
-        return transaction { ArbeidsOppfolgingKontorEntity.findById(fnr) }
+        return transaction { getAOKontor(fnr) }
             ?.let { it to kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
-            ?.let { (kontor, kontorNavn) ->
-                ArbeidsoppfolgingsKontor(
-                    kontorNavn,
-                    kontor.getKontorId(),
-                )
-            }
+            ?.let { (kontor, kontorNavn) -> ArbeidsoppfolgingsKontor(kontorNavn,kontor.getKontorId()) }
     }
 
     suspend fun getArenaKontorTilhorighet(fnr: Fnr): ArenaKontor? {
-        return transaction { ArenaKontorEntity.findById(fnr) }
+        return transaction { getArenaKontor(fnr) }
             ?.let { it to kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
-            ?.let { (kontor, kontorNavn) ->
-                ArenaKontor(
-                    kontorNavn,
-                    kontor.getKontorId(),
-                )
-            }
+            ?.let { (kontor, kontorNavn) -> ArenaKontor(kontorNavn, kontor.getKontorId()) }
     }
 
     suspend fun getGeografiskTilknyttetKontorTilhorighet(fnr: Fnr): GeografiskTilknyttetKontor? {
-        return transaction { GeografiskTilknyttetKontorEntity.findById(fnr) }
+        return transaction { getGTKontor(fnr) }
             ?.let { it to kontorNavnService.getKontorNavn(KontorId(it.kontorId)) }
-            ?.let { (kontor, kontorNavn) ->
-                GeografiskTilknyttetKontor(
-                    kontorNavn,
-                    kontor.getKontorId(),
-                )
-            }
+            ?.let { (kontor, kontorNavn) -> GeografiskTilknyttetKontor(kontorNavn,kontor.getKontorId()) }
     }
 
-    fun getGTKontor(fnr: Fnr) = GeografiskTilknyttetKontorEntity.findById(fnr)
-    fun getArenaKontor(fnr: Fnr) = ArenaKontorEntity.findById(fnr)
-    fun getAOKontor(fnr: Fnr) = ArbeidsOppfolgingKontorEntity.findById(fnr)
+    private fun getGTKontor(fnr: Fnr) = GeografiskTilknyttetKontorEntity.findById(fnr)
+    private fun getArenaKontor(fnr: Fnr) = ArenaKontorEntity.findById(fnr)
+    private fun getAOKontor(fnr: Fnr) = ArbeidsOppfolgingKontorEntity.findById(fnr)
 
     suspend fun getKontorTilhorighet(fnr: Fnr): KontorTilhorighetQueryDto? {
         return newSuspendedTransaction {

--- a/src/main/resources/graphql/queries/hentKonto.graphql
+++ b/src/main/resources/graphql/queries/hentKonto.graphql
@@ -1,5 +1,5 @@
 query($fnr: String!) {
-    kontorForBruker(fnrParam: $fnr) {
+    kontorForBruker(fnr: $fnr) {
         kontorId
         kilde
     }

--- a/src/test/kotlin/no/nav/AuthenticationTest.kt
+++ b/src/test/kotlin/no/nav/AuthenticationTest.kt
@@ -9,9 +9,14 @@ import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import no.nav.configureSecurity
+import no.nav.http.client.Norg2Client
+import no.nav.http.client.mockNorg2Host
 import no.nav.http.client.norg2TestUrl
 import no.nav.http.graphql.configureGraphQlModule
+import no.nav.http.graphql.getNorg2Url
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.services.KontorNavnService
+import no.nav.services.KontorTilhorighetService
 import no.nav.utils.getJsonHttpClient
 import no.nav.utils.kontorTilhorighetQuery
 import org.junit.Test
@@ -23,8 +28,12 @@ class AuthenticationTest {
             config = getMockOauth2ServerConfig()
         }
         application {
+            val norg2Client = Norg2Client(environment.getNorg2Url())
             configureSecurity()
-            configureGraphQlModule()
+            configureGraphQlModule(
+                norg2Client,
+                KontorTilhorighetService(KontorNavnService(norg2Client))
+            )
         }
     }
 

--- a/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
+++ b/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
@@ -17,6 +17,7 @@ import no.nav.http.client.mockNorg2Host
 import no.nav.http.graphql.installGraphQl
 import no.nav.http.graphql.schemas.KontorHistorikkQueryDto
 import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
+import no.nav.http.graphql.schemas.RegistrantTypeDto
 import no.nav.services.KontorNavnService
 import no.nav.services.KontorTilhorighetService
 import no.nav.utils.AlleKontor
@@ -60,7 +61,9 @@ class GraphqlApplicationTest {
 
         response.status shouldBe HttpStatusCode.Companion.OK
         val payload = response.body<GraphqlResponse<KontorTilhorighet>>()
-        payload shouldBe GraphqlResponse(KontorTilhorighet(KontorTilhorighetQueryDto(kontorId, KontorKilde.ARENA)))
+        payload shouldBe GraphqlResponse(KontorTilhorighet(
+            KontorTilhorighetQueryDto(kontorId, KontorKilde.ARENA, "Arena", RegistrantTypeDto.ARENA))
+        )
     }
 
     @Test

--- a/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
+++ b/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
@@ -62,7 +62,7 @@ class GraphqlApplicationTest {
         response.status shouldBe HttpStatusCode.Companion.OK
         val payload = response.body<GraphqlResponse<KontorTilhorighet>>()
         payload shouldBe GraphqlResponse(KontorTilhorighet(
-            KontorTilhorighetQueryDto(kontorId, KontorKilde.ARENA, "Arena", RegistrantTypeDto.ARENA))
+            KontorTilhorighetQueryDto(kontorId, "NAV test", KontorKilde.ARENA, "Arena", RegistrantTypeDto.ARENA))
         )
     }
 

--- a/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
+++ b/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
@@ -17,6 +17,8 @@ import no.nav.http.client.mockNorg2Host
 import no.nav.http.graphql.installGraphQl
 import no.nav.http.graphql.schemas.KontorHistorikkQueryDto
 import no.nav.http.graphql.schemas.KontorTilhorighetQueryDto
+import no.nav.services.KontorNavnService
+import no.nav.services.KontorTilhorighetService
 import no.nav.utils.AlleKontor
 import no.nav.utils.GraphqlResponse
 import no.nav.utils.KontorTilhorighet
@@ -35,7 +37,7 @@ fun ApplicationTestBuilder.graphqlServerInTest() {
     val norg2Client = mockNorg2Host()
     application {
         flywayMigrationInTest()
-        installGraphQl(norg2Client)
+        installGraphQl(norg2Client, KontorTilhorighetService(KontorNavnService(norg2Client)))
         routing {
             graphQLPostRoute()
         }

--- a/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
+++ b/src/test/kotlin/no/nav/GraphqlApplicationTest.kt
@@ -118,6 +118,24 @@ class GraphqlApplicationTest {
     }
 
     @Test
+    fun `skal få GT kontor på tilhørighet hvis ingen andre kontor er satt via graphql`() = testApplication {
+        val fnr = "32345678901"
+        val kontorId = "4142"
+        val client = getJsonHttpClient()
+        graphqlServerInTest()
+        application {
+            gittBrukerMedGeografiskTilknyttetKontor(fnr, kontorId)
+        }
+
+        val response = client.kontorTilhorighet(fnr)
+
+        response.status shouldBe HttpStatusCode.Companion.OK
+        val payload = response.body<GraphqlResponse<KontorTilhorighet>>()
+        payload.errors shouldBe null
+        payload.data!!.kontorTilhorighet?.kontorId shouldBe kontorId
+    }
+
+    @Test
     fun `skal kunne hente ao-kontor, arena-kontor og gt-kontor samtidig`() = testApplication {
         val fnr = "62345678901"
         val GTkontorId = "4151"

--- a/src/test/kotlin/no/nav/SettArbeidsoppfolgingsKontorTest.kt
+++ b/src/test/kotlin/no/nav/SettArbeidsoppfolgingsKontorTest.kt
@@ -3,6 +3,7 @@ package no.nav
 import com.expediagroup.graphql.server.ktor.graphQLPostRoute
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authentication
 import io.ktor.server.config.MapApplicationConfig
@@ -10,6 +11,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import no.nav.domain.KontorKilde
+import no.nav.http.client.logger
 import no.nav.http.client.mockNorg2Host
 import no.nav.http.client.norg2TestUrl
 import no.nav.http.client.settKontor
@@ -43,7 +45,6 @@ class SettArbeidsoppfolgingsKontorTest {
                 kontorNavnService,
                 kontorTilhorighetService
             )
-            configureHTTP()
             routing {
                 authentication {
                     graphQLPostRoute()
@@ -66,6 +67,8 @@ class SettArbeidsoppfolgingsKontorTest {
 
             val readResponse = httpClient.kontorTilhorighet(fnr)
             readResponse.status shouldBe HttpStatusCode.OK
+            val text = readResponse.bodyAsText()
+            logger.info("BODY: $text")
             val kontorResponse = readResponse.body<GraphqlResponse<KontorTilhorighet>>()
             kontorResponse.errors shouldBe null
             kontorResponse.data?.kontorTilhorighet?.kontorId shouldBe kontorId

--- a/src/test/kotlin/no/nav/http/client/KontorClient.kt
+++ b/src/test/kotlin/no/nav/http/client/KontorClient.kt
@@ -14,6 +14,7 @@ suspend fun HttpClient.settKontor(server: MockOAuth2Server, kontorId: String, fn
             claims = mapOf("NAVident" to "$navIdent")
         ).serialize()}")
         header("Content-Type", "application/json")
+        header("Accept", "application/json")
         setBody("""{ "kontorId": "$kontorId", "fnr": "$fnr", "begrunnelse": null }""")
     }
 }

--- a/src/test/kotlin/no/nav/http/client/Norg2ClientMocking.kt
+++ b/src/test/kotlin/no/nav/http/client/Norg2ClientMocking.kt
@@ -5,23 +5,55 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
-import no.nav.configureContentNegotiation
+import kotlinx.serialization.json.Json
+import no.nav.http.logger
+import org.slf4j.LoggerFactory
 
 val norg2TestUrl = "https://norg2.test.no"
 
+val logger = LoggerFactory.getLogger("ApplicationTestBuilder.mockNorg2Host")
+
 fun ApplicationTestBuilder.mockNorg2Host(): Norg2Client {
+    logger.info("Mocking norg2 host: $norg2TestUrl${Norg2Client.hentEnhetPathWithParam}")
     externalServices {
         hosts(norg2TestUrl) {
-            configureContentNegotiation()
+            install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
+                json()
+            }
             routing {
-                get(Norg2Client.hentEnhetPath) {
+                get(Norg2Client.hentEnheterPath) {
                     val fileContent = javaClass.getResource("/norg2enheter.json")?.readText()
                         ?: throw IllegalStateException("File norg2enheter.json not found")
                     call.respondText(fileContent, ContentType.Application.Json)
+                }
+                get(Norg2Client.hentEnhetPathWithParam) {
+                    val enhetId = call.pathParameters["enhetId"] ?: throw IllegalArgumentException("EnhetId not found in path")
+                    val kontor = NorgKontor(
+                        enhetId = enhetId.toLong(),
+                        navn = "NAV test",
+                        enhetNr = enhetId,
+                        antallRessurser = 2,
+                        status = "AKTIV",
+                        orgNivaa = "4",
+                        type = "LOKAL",
+                        organisasjonsnummer = "123456789",
+                        underEtableringDato = null,
+                        aktiveringsdato = null,
+                        underAvviklingDato = null,
+                        nedleggelsesdato = null,
+                        oppgavebehandler = true,
+                        versjon = 1,
+                        sosialeTjenester = null,
+                        kanalstrategi = null,
+                        orgNrTilKommunaltNavKontor = null,
+                    )
+                    call.respond(kontor)
                 }
             }
         }

--- a/src/test/kotlin/no/nav/http/client/Norg2ClientMocking.kt
+++ b/src/test/kotlin/no/nav/http/client/Norg2ClientMocking.kt
@@ -23,10 +23,10 @@ fun ApplicationTestBuilder.mockNorg2Host(): Norg2Client {
     logger.info("Mocking norg2 host: $norg2TestUrl${Norg2Client.hentEnhetPathWithParam}")
     externalServices {
         hosts(norg2TestUrl) {
-            install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
-                json()
-            }
             routing {
+                install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
+                    json()
+                }
                 get(Norg2Client.hentEnheterPath) {
                     val fileContent = javaClass.getResource("/norg2enheter.json")?.readText()
                         ?: throw IllegalStateException("File norg2enheter.json not found")

--- a/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
+++ b/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
@@ -9,7 +9,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.serialization.Serializable
 import no.nav.db.Fnr
-import no.nav.domain.KontorNavn
 import no.nav.http.client.logger
 import no.nav.http.graphql.schemas.AlleKontorQueryDto
 import no.nav.http.graphql.schemas.ArbeidsoppfolgingKontorDto

--- a/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
+++ b/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
@@ -83,7 +83,7 @@ private fun kontorHistorikkQuery(fnr: Fnr): String {
 }
 fun kontorTilhorighetQuery(fnr: Fnr): String {
     return graphqlPayload(fnr, """
-             { kontorTilhorighet (fnrParam: \"$fnr\") { kontorId , kilde, registrant, registrantType } }
+             { kontorTilhorighet (fnrParam: \"$fnr\") { kontorId , kilde, registrant, registrantType, kontorNavn } }
         """.trimIndent())
 }
 private fun alleKontorQuery(): String {

--- a/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
+++ b/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
@@ -78,12 +78,12 @@ suspend fun HttpClient.alleKontor(): HttpResponse {
 
 private fun kontorHistorikkQuery(fnr: Fnr): String {
     return graphqlPayload(fnr, """
-            { kontorHistorikk (fnrParam: \"$fnr\") { kontorId , kilde, endretAv, endretAvType, endretTidspunkt, endringsType } }
+            { kontorHistorikk (fnr: \"$fnr\") { kontorId , kilde, endretAv, endretAvType, endretTidspunkt, endringsType } }
         """.trimIndent())
 }
 fun kontorTilhorighetQuery(fnr: Fnr): String {
     return graphqlPayload(fnr, """
-             { kontorTilhorighet (fnrParam: \"$fnr\") { kontorId , kilde, registrant, registrantType, kontorNavn } }
+             { kontorTilhorighet (fnr: \"$fnr\") { kontorId , kilde, registrant, registrantType, kontorNavn } }
         """.trimIndent())
 }
 private fun alleKontorQuery(): String {

--- a/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
+++ b/src/test/kotlin/no/nav/utils/GraphqlResponse.kt
@@ -40,7 +40,7 @@ data class GraphqlErrorLocation(
 
 @Serializable
 data class KontorTilhorighet(
-    val kontorTilhorighet: KontorTilhorighetQueryDto,
+    val kontorTilhorighet: KontorTilhorighetQueryDto?,
 )
 
 @Serializable
@@ -83,7 +83,7 @@ private fun kontorHistorikkQuery(fnr: Fnr): String {
 }
 fun kontorTilhorighetQuery(fnr: Fnr): String {
     return graphqlPayload(fnr, """
-             { kontorTilhorighet (fnrParam: \"$fnr\") { kontorId , kilde } }
+             { kontorTilhorighet (fnrParam: \"$fnr\") { kontorId , kilde, registrant, registrantType } }
         """.trimIndent())
 }
 private fun alleKontorQuery(): String {


### PR DESCRIPTION
- Utvid norg-client med mulighet for å hente navnet på 1 kontor
- Lagde en "service" for å hente kontornavn, slik at man senere skal kunne bytte til cachet-kontornavn (kanskje egen tabell?) uten å endre API-et direkte
- Lagde en "service" for å hent ut kontor, tidligere hadde vi all logikk inni selve graphql-Query klassen, tenkte det var fint å separere disse og bare beholde enkle kall til service og mapping til DTO i Query klassene 
- Lagde Type-klasser for kontor-id og kontor-navn siden begge disse er string-er og kan være nyttig å type disse sterkt
- Gi ut "Kvittering" med hvilke kontor man ble endret fra og til på sett-kontor endepunkt
- Graphql spørring for å hente alle nåværende kontortilhørigheter (ao, arena, gt)

Har prøvd å følge en konvensjon hvor alle klasser som brukes direkte i API-ene, enten graphql eller REST er postfixed med "DTO". Klasser som flytter data ut av DB er på en måte også DTO-klasser men prøvde å unngå å kalle dem DTO for å ikke forveksle dem med DTO-ene som gis ut på API-ene