### PR TITLE
Fallback to sync pdl when no match on aktorId from topic

### DIFF
--- a/src/main/kotlin/kafka/consumers/IdentChangeProcessor.kt
+++ b/src/main/kotlin/kafka/consumers/IdentChangeProcessor.kt
@@ -27,7 +27,7 @@ class IdentChangeProcessor(
                     } else {
                         val nyeIdenter = payload.identifikatorer
                             .map { OppdatertIdent(Ident.of(it.idnummer), !it.gjeldende) }
-                        identService.hånterEndringPåIdenter(aktorId, nyeIdenter)
+                        identService.håndterEndringPåIdenter(aktorId, nyeIdenter)
                         Commit<String, Aktor>()
                     }
                 }

--- a/src/main/kotlin/services/IdentService.kt
+++ b/src/main/kotlin/services/IdentService.kt
@@ -174,7 +174,7 @@ class IdentService(
     }
 
     /**
-     * Henter alle koblebe identer utenom historiske
+     * Henter alle koblede identer utenom historiske
      */
     private fun hentIdentMappinger(identInput: Ident): List<Ident> = hentIdentMappinger(identInput, false).map { it.ident }
     private fun hentIdentMappinger(identInput: Ident, includeHistorisk: Boolean): List<IdentInfo> = transaction {

--- a/src/main/kotlin/services/IdentService.kt
+++ b/src/main/kotlin/services/IdentService.kt
@@ -22,7 +22,6 @@ import no.nav.http.client.IdenterResult
 import no.nav.http.client.finnForetrukketIdent
 import no.nav.http.graphql.generated.client.hentfnrquery.IdentInformasjon
 import org.jetbrains.exposed.sql.JoinType
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.andWhere
@@ -54,9 +53,9 @@ class IdentService(
     }
 
     /* Tenkt kalt ved endring på aktor-v2 topic (endring i identer) */
-    suspend fun hånterEndringPåIdenter(ident: Ident): IdenterResult = hentAlleIdenterOgOppdaterMapping(ident)
+    suspend fun håndterEndringPåIdenter(ident: Ident): IdenterResult = hentAlleIdenterOgOppdaterMapping(ident)
 
-    suspend fun hånterEndringPåIdenter(aktorId: AktorId, nyeIdenter: List<OppdatertIdent>): Int {
+    suspend fun håndterEndringPåIdenter(aktorId: AktorId, nyeIdenter: List<OppdatertIdent>): Int {
         val eksisterendeIdenter = hentIdentMappinger(aktorId, includeHistorisk = true)
         if(eksisterendeIdenter.isEmpty()) return 0
 

--- a/src/test/kotlin/services/IdentServiceTest.kt
+++ b/src/test/kotlin/services/IdentServiceTest.kt
@@ -20,12 +20,14 @@ import no.nav.http.graphql.generated.client.enums.IdentGruppe
 import no.nav.http.graphql.generated.client.hentfnrquery.IdentInformasjon
 import no.nav.person.pdl.aktor.v2.Aktor
 import no.nav.person.pdl.aktor.v2.Identifikator
+import no.nav.person.pdl.aktor.v2.Type
 import no.nav.utils.flywayMigrationInTest
 import org.apache.kafka.streams.processor.api.Record
+import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.batchUpsert
-import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
 
 class IdentServiceTest {
 
@@ -274,10 +276,14 @@ class IdentServiceTest {
     fun `aktor-v2 endring - skal ikke oppdatere identer når vi ikke har noe intern-ident på bruker`() = runTest {
         flywayMigrationInTest()
 
-        val identProvider: suspend (String) -> IdenterFunnet = { aktorId -> IdenterFunnet(emptyList(), aktorId) }
-        val identService = IdentService(identProvider)
         val aktorId = AktorId("2938764298763")
-        val fnr = Fnr("38764298763")
+        val fnr = Fnr("18111298763")
+
+        val identProvider: suspend (String) -> IdenterFunnet = { innkommendeAktorId -> IdenterFunnet(listOf(
+            IdentInformasjon(aktorId.value, false) ,
+            IdentInformasjon(fnr.value, false),
+        ), innkommendeAktorId) }
+        val identService = IdentService(identProvider)
 
         val innkommendeIdenter = listOf(
             OppdatertIdent(aktorId, false),
@@ -314,6 +320,50 @@ class IdentServiceTest {
         hentIdenter(internId) shouldBe listOf(
             IdentFraDb(aktorId.value, "AKTOR_ID", false, true),
             IdentFraDb(fnr.value, "FNR", false, false),
+        )
+    }
+
+    @Test
+    fun `skal finne internId på ny aktørId selvom gammel aktørId er opphørt hvis fnr finnes`() = runTest {
+        flywayMigrationInTest()
+
+        val oppohortAktorId = AktorId("4938764598763")
+        val nyAktorId = AktorId("2938764297763")
+        val fnr = Fnr("02010198765")
+        val internId = 31231L
+
+        /* AktorId er slettet, men det finnes fortsatt FNR som ikke er slettet */
+        transaction {
+            IdentMappingTable.batchInsert(listOf(oppohortAktorId, fnr)) {
+                this[IdentMappingTable.internIdent] = internId
+                this[IdentMappingTable.historisk] = false
+                this[IdentMappingTable.id] = it.value
+                this[IdentMappingTable.identType] = it.toIdentType()
+                this[IdentMappingTable.slettetHosOss] = if (it is AktorId) OffsetDateTime.now() else null
+            }
+        }
+
+        val identProvider: suspend (String) -> IdenterFunnet = { nyMenIkkeLagretEndaAktorId ->
+            IdenterFunnet(listOf(
+                IdentInformasjon(fnr.value, false, IdentGruppe.FOLKEREGISTERIDENT),
+                IdentInformasjon(nyAktorId.value, false, IdentGruppe.AKTORID)
+            ), nyMenIkkeLagretEndaAktorId)
+        }
+        val identService = IdentService(identProvider)
+        val proccessor = IdentChangeProcessor(identService)
+
+        val payload = mockk<Aktor> {
+            every { identifikatorer } returns listOf(
+                Identifikator(fnr.value, Type.FOLKEREGISTERIDENT, true),
+                Identifikator(nyAktorId.value, Type.AKTORID, true),
+            )
+        }
+        proccessor.process(Record(nyAktorId.value, payload, 1010L))
+
+        hentIdenter(internId) shouldBe listOf(
+            IdentFraDb(oppohortAktorId.value, "AKTOR_ID", false, true),
+            IdentFraDb(fnr.value, "FNR", false, false),
+            IdentFraDb(nyAktorId.value, "AKTOR_ID", false, false),
         )
     }
 

--- a/src/test/kotlin/services/IdentServiceTest.kt
+++ b/src/test/kotlin/services/IdentServiceTest.kt
@@ -327,14 +327,14 @@ class IdentServiceTest {
     fun `skal finne internId på ny aktørId selvom gammel aktørId er opphørt hvis fnr finnes`() = runTest {
         flywayMigrationInTest()
 
-        val oppohortAktorId = AktorId("4938764598763")
+        val opphortAktorId = AktorId("4938764598763")
         val nyAktorId = AktorId("2938764297763")
         val fnr = Fnr("02010198765")
         val internId = 31231L
 
         /* AktorId er slettet, men det finnes fortsatt FNR som ikke er slettet */
         transaction {
-            IdentMappingTable.batchInsert(listOf(oppohortAktorId, fnr)) {
+            IdentMappingTable.batchInsert(listOf(opphortAktorId, fnr)) {
                 this[IdentMappingTable.internIdent] = internId
                 this[IdentMappingTable.historisk] = false
                 this[IdentMappingTable.id] = it.value
@@ -361,7 +361,7 @@ class IdentServiceTest {
         proccessor.process(Record(nyAktorId.value, payload, 1010L))
 
         hentIdenter(internId) shouldBe listOf(
-            IdentFraDb(oppohortAktorId.value, "AKTOR_ID", false, true),
+            IdentFraDb(opphortAktorId.value, "AKTOR_ID", false, true),
             IdentFraDb(fnr.value, "FNR", false, false),
             IdentFraDb(nyAktorId.value, "AKTOR_ID", false, false),
         )


### PR DESCRIPTION
Scenario
AktorId-1 -> AktorId-1 , Fnr-1
// Aktorid-2 opphører, men fnr fortsetter
AktorId-2 -> AktorId-2, Fnr-1 

Her er det viktig at vi gjenbruker samme internId, dvs hvis vi ikke får noen treff i vår database bør vi spørre pdl synkront for så å sjekke mot alle de identene (Fnr-1)
