### PR TITLE
Verifiser ønsket oppførsel ved relesing av oppfølgingsperiodemelding

### DIFF
--- a/src/test/kotlin/kafka/consumers/OppfolgingsPeriodeConsumerTest.kt
+++ b/src/test/kotlin/kafka/consumers/OppfolgingsPeriodeConsumerTest.kt
@@ -11,7 +11,6 @@ import java.util.UUID
 import no.nav.db.Fnr
 import no.nav.db.entity.OppfolgingsperiodeEntity
 import no.nav.db.table.OppfolgingsperiodeTable
-import no.nav.db.table.OppfolgingsperiodeTable.oppfolgingsperiodeId
 import no.nav.domain.OppfolgingsperiodeId
 import no.nav.domain.externalEvents.OppfolgingsperiodeStartet
 import no.nav.http.client.IdentFunnet


### PR DESCRIPTION
Med tanke på lagring av data er vi idempotente når vi leser en sisteOppfølgingsperiode-melding på nytt siden vi bruker upsert på fødselsnummer. 

Litt usikker på om det er riktig at vi i et slikt tilfelle skal returnere Forward fra prosesseringsmetoden. Heller mot ja, siden vi dersom det er behov kan lese fra starten av køen igjen og få beregnet ao-kontor på nytt. I en normaltilstand skal det aldri skje at vi leser samme melding på nytt. 