### PR TITLE
Ignorer melding om skjerming for bruker som ikke er under oppfølging

### DIFF
--- a/src/main/kotlin/kafka/consumers/SkjermingProcessor.kt
+++ b/src/main/kotlin/kafka/consumers/SkjermingProcessor.kt
@@ -42,27 +42,25 @@ class SkjermingProcessor(
                     val result = automatiskKontorRutingService.handterEndringISkjermingStatus(
                         SkjermetStatusEndret(ident, HarSkjerming(skjermingStatus))
                     )
-                    when (result.isSuccess) {
-                        true -> {
-                            val endringResult = result.getOrNull()
-                            log.info("Behandling endring i skjerming med resultat: $endringResult")
-                            if (endringResult != null) {
-                                endringResult.let { kontorTilordningService.tilordneKontor(it.endringer) }
-                                if (endringResult.endringer.aoKontorEndret != null) {
-                                    val record = endringResult.endringer.aoKontorEndret.toOppfolgingEndretTilordningMeldingRecord()
-                                    Forward(record)
-                                } else {
-                                    log.error("Fikk melding om endring av skjermet men klarte ikke å sette nytt kontor: $endringResult")
-                                    Retry("Fikk melding om endring av skjermet men klarte ikke å sette nytt kontor: $endringResult")
-                                }
+                    when (result) {
+                        is EndringISkjermingSuccess -> {
+                            log.info("Behandling endring i skjerming med resultat: $result")
+                            kontorTilordningService.tilordneKontor(result.endringer)
+                            if (result.endringer.aoKontorEndret != null) {
+                                val record = result.endringer.aoKontorEndret.toOppfolgingEndretTilordningMeldingRecord()
+                                Forward(record)
                             } else {
-                                Commit()
+                                log.error("Fikk melding om endring av skjermet men klarte ikke å sette nytt kontor: $result")
+                                Retry("Fikk melding om endring av skjermet men klarte ikke å sette nytt kontor: $result")
                             }
                         }
-                        false -> {
-                            val exception = result.exceptionOrNull()
-                            log.error("Kunne ikke behandle melding om endring i skjermingstatus", exception)
-                            Retry("Kunne ikke behandle melding om endring i skjermingstatus: ${exception?.message}")
+                        EndringISkjermingBrukerIkkeUnderOppfølging -> {
+                            log.info("Fikk melding om skjerming for bruker som ikke er under oppfølging, ignorerer melding")
+                            Commit()
+                        }
+                        is EndringISkjermingBehandlingFeilet -> {
+                            log.error("Kunne ikke behandle melding om endring i skjermingstatus", result.exception)
+                            Retry("Kunne ikke behandle melding om endring i skjermingstatus: ${result.exception.message}")
                         }
                     }
                 },
@@ -74,6 +72,11 @@ class SkjermingProcessor(
     }
 }
 
-data class EndringISkjermingResult(
+sealed interface EndringISkjermingResult
+
+data class EndringISkjermingSuccess(
     val endringer: KontorEndringer
-)
+): EndringISkjermingResult
+
+object EndringISkjermingBrukerIkkeUnderOppfølging: EndringISkjermingResult
+data class EndringISkjermingBehandlingFeilet(val exception: Exception): EndringISkjermingResult

--- a/src/main/kotlin/services/AutomatiskKontorRutingService.kt
+++ b/src/main/kotlin/services/AutomatiskKontorRutingService.kt
@@ -54,7 +54,7 @@ import no.nav.http.client.arbeidssogerregisteret.ProfileringIkkeAktuell
 import no.nav.http.client.arbeidssogerregisteret.ProfileringIkkeFunnet
 import no.nav.http.client.arbeidssogerregisteret.ProfileringsResultat
 import no.nav.http.client.arbeidssogerregisteret.ProfileringOppslagFeil
-import no.nav.kafka.consumers.EndringISkjermingResult
+import no.nav.kafka.consumers.EndringISkjermingSuccess
 import no.nav.kafka.consumers.HåndterPersondataEndretFail
 import no.nav.kafka.consumers.HåndterPersondataEndretResultat
 import no.nav.kafka.consumers.HåndterPersondataEndretSuccess
@@ -67,6 +67,9 @@ import java.time.ZonedDateTime
 import no.nav.domain.ArbeidsoppfolgingsKontor
 import no.nav.domain.System
 import no.nav.domain.events.AOKontorEndretPgaNorskGT
+import no.nav.kafka.consumers.EndringISkjermingBehandlingFeilet
+import no.nav.kafka.consumers.EndringISkjermingBrukerIkkeUnderOppfølging
+import no.nav.kafka.consumers.EndringISkjermingResult
 
 sealed class TilordningResultat
 sealed class TilordningSuccess : TilordningResultat()
@@ -462,14 +465,14 @@ data class AutomatiskKontorRutingService(
 
     suspend fun handterEndringISkjermingStatus(
         endringISkjermingStatus: SkjermetStatusEndret
-    ): Result<EndringISkjermingResult> {
+    ): EndringISkjermingResult {
         return runCatching {
             val oppfolgingsperiodeId =
                 when (val result = hentGjeldendeOppfolgingsperiode(endringISkjermingStatus.fnr)) {
                     is AktivOppfolgingsperiode -> result.periodeId
-                    NotUnderOppfolging -> return Result.success(EndringISkjermingResult(KontorEndringer()))
+                    NotUnderOppfolging -> return EndringISkjermingBrukerIkkeUnderOppfølging
                     is OppfolgingperiodeOppslagFeil ->
-                        return Result.failure(
+                        return EndringISkjermingBehandlingFeilet(
                             Exception("Kunne ikke håndtere endring i skjerming pga feil ved henting av oppfolgingsstatus: ${result.message}")
                         )
                 }
@@ -477,14 +480,14 @@ data class AutomatiskKontorRutingService(
             val harStrengtFortroligAdresse =
                 when (val result = hentHarStrengtFortroligAdresse(endringISkjermingStatus.fnr)) {
                     is HarStrengtFortroligAdresseIkkeFunnet ->
-                        return Result.failure(
+                        return EndringISkjermingBehandlingFeilet(
                             Exception(
                                 "Kunne ikke hente adressebeskyttelse ved endring i skjermingstatus: ${result.message}"
                             )
                         )
 
                     is HarStrengtFortroligAdresseOppslagFeil ->
-                        return Result.failure(
+                        return EndringISkjermingBehandlingFeilet(
                             Exception(
                                 "Kunne ikke hente adressebeskyttelse ved endring i skjermingstatus: ${result.message}"
                             )
@@ -520,16 +523,20 @@ data class AutomatiskKontorRutingService(
                         aoKontorEndret = aoKontorEndring,
                         gtKontorEndret = gtKontorEndring,
                     )
-                    Result.success(EndringISkjermingResult(kontorEndringer))
+                    EndringISkjermingSuccess(kontorEndringer)
                 }
 
                 is KontorForGtFeil -> {
                     val feilmelding =
                         "Kunne ikke håndtere endring i skjerming pga feil ved henting av gt-kontor: ${gtKontorResultat.melding}"
                     log.error(feilmelding)
-                    return Result.failure(Exception(feilmelding))
+                    EndringISkjermingBehandlingFeilet(Exception(feilmelding))
                 }
             }
+        }.getOrElse { error ->
+            EndringISkjermingBehandlingFeilet(
+                Exception("Uventet feil ved håndtering av endring i skjerming: ${error.message}", error)
+            )
         }
     }
 

--- a/src/test/kotlin/no/nav/KafkaApplicationTest.kt
+++ b/src/test/kotlin/no/nav/KafkaApplicationTest.kt
@@ -246,7 +246,7 @@ class KafkaApplicationTest {
                 KontorHistorikkEntity
                     .find { KontorhistorikkTable.ident eq fnr.value }
                     .count() shouldBe 0
-                FailedMessagesEntity.all().count() shouldBe 0
+                FailedMessagesEntity.all().filter { it.topic == topic }.count() shouldBe 0
             }
         }
     }

--- a/src/test/kotlin/no/nav/KafkaApplicationTest.kt
+++ b/src/test/kotlin/no/nav/KafkaApplicationTest.kt
@@ -22,6 +22,7 @@ import no.nav.db.entity.ArbeidsOppfolgingKontorEntity
 import no.nav.db.entity.ArenaKontorEntity
 import no.nav.db.entity.GeografiskTilknyttetKontorEntity
 import no.nav.db.entity.KontorHistorikkEntity
+import no.nav.db.table.FailedMessagesEntity
 import no.nav.db.table.KontorhistorikkTable
 import no.nav.domain.HarSkjerming
 import no.nav.domain.HarStrengtFortroligAdresse
@@ -46,6 +47,8 @@ import no.nav.kafka.retry.library.internal.RetryableRepository
 import no.nav.services.AktivOppfolgingsperiode
 import no.nav.services.AutomatiskKontorRutingService
 import no.nav.services.KontorTilhorighetService
+import no.nav.services.NotUnderOppfolging
+import no.nav.services.OppfolgingsperiodeOppslagResult
 import no.nav.utils.flywayMigrationInTest
 import no.nav.utils.gittBrukerUnderOppfolging
 import no.nav.utils.kontorTilordningService
@@ -198,6 +201,52 @@ class KafkaApplicationTest {
                 KontorHistorikkEntity
                     .find { KontorhistorikkTable.ident eq fnr.value }
                     .count() shouldBe 2
+            }
+        }
+    }
+
+    @Test
+    fun `skal ignorere melding om skjerming for bruker som ikke er under oppfølging`() = testApplication {
+        val fnr =  randomFnr(UKJENT)
+        val skjermetKontor = "4555"
+        val topic = randomTopicName()
+
+        val automatiskKontorRutingService = AutomatiskKontorRutingService(
+            { _, b, a ->
+                KontorForGtFantDefaultKontor(
+                    KontorId(skjermetKontor),
+                    a,
+                    b,
+                    GeografiskTilknytningBydelNr("3131")
+                )
+            },
+            { AlderFunnet(40) },
+            { ProfileringFunnet(ProfileringsResultat.ANTATT_GODE_MULIGHETER) },
+            { SkjermingFunnet(HarSkjerming(true)) },
+            { HarStrengtFortroligAdresseFunnet(HarStrengtFortroligAdresse(false)) },
+            { NotUnderOppfolging },
+            { _, _ -> Outcome.Success(false) },
+            { null },
+        )
+        val skjermingProcessor = SkjermingProcessor(
+            automatiskKontorRutingService,
+            kontorTilordningService,
+        )
+
+        application {
+            flywayMigrationInTest()
+            val topology = configureStringOptionalStringInputTopology(skjermingProcessor::process, topic)
+            val kafkaMockTopic = setupKafkaMock(topology, topic)
+
+            kafkaMockTopic.pipeInput(fnr.value, "true")
+
+            transaction {
+                GeografiskTilknyttetKontorEntity.findById(fnr.value)?.kontorId shouldBe null
+                ArbeidsOppfolgingKontorEntity.findById(fnr.value)?.kontorId shouldBe null
+                KontorHistorikkEntity
+                    .find { KontorhistorikkTable.ident eq fnr.value }
+                    .count() shouldBe 0
+                FailedMessagesEntity.all().count() shouldBe 0
             }
         }
     }

--- a/src/test/kotlin/services/AutomatiskKontorRutingServiceTest.kt
+++ b/src/test/kotlin/services/AutomatiskKontorRutingServiceTest.kt
@@ -17,8 +17,10 @@ import domain.kontorForGt.KontorForGtNrFantFallbackKontorForManglendeGt
 import domain.kontorForGt.KontorForGtResultat
 import domain.kontorForGt.KontorForGtSuccess
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import java.time.OffsetDateTime
 import java.util.UUID
 import kafka.consumers.oppfolgingsHendelser.StartetAvType
@@ -69,7 +71,9 @@ import no.nav.http.client.arbeidssogerregisteret.HentProfileringsResultat
 import no.nav.http.client.arbeidssogerregisteret.ProfileringFunnet
 import no.nav.http.client.arbeidssogerregisteret.ProfileringIkkeFunnet
 import no.nav.http.client.arbeidssogerregisteret.ProfileringsResultat
-import no.nav.kafka.consumers.EndringISkjermingResult
+import no.nav.kafka.consumers.EndringISkjermingBehandlingFeilet
+import no.nav.kafka.consumers.EndringISkjermingBrukerIkkeUnderOppfølging
+import no.nav.kafka.consumers.EndringISkjermingSuccess
 import no.nav.kafka.consumers.HåndterPersondataEndretFail
 import no.nav.kafka.consumers.HåndterPersondataEndretSuccess
 import no.nav.kafka.consumers.KontorEndringer
@@ -593,28 +597,26 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
                     ungBrukerMedGodeMuligheter.fnr(),
                     HarSkjerming(true)
                 )
-            ) shouldBe Result.success(
-                EndringISkjermingResult(
-                    KontorEndringer(
-                        gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
-                            KontorTilordning(
-                                ungBrukerMedGodeMuligheter.fnr(),
-                                ungBrukerMedGodeMuligheter.gtKontor(),
-                                ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
-                            ),
-                            HarSkjerming(true),
-                            ungBrukerMedGodeMuligheter.gtForBruker as GtForBrukerFunnet
+            ) shouldBe EndringISkjermingSuccess(
+                KontorEndringer(
+                    gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
+                        KontorTilordning(
+                            ungBrukerMedGodeMuligheter.fnr(),
+                            ungBrukerMedGodeMuligheter.gtKontor(),
+                            ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
                         ),
-                        aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
-                            KontorTilordning(
-                                ungBrukerMedGodeMuligheter.fnr(),
-                                ungBrukerMedGodeMuligheter.gtKontor(),
-                                ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
-                            ),
-                            skjerming = HarSkjerming(true),
-                            registrant = System(Systemnavn.SKJERMING),
+                        HarSkjerming(true),
+                        ungBrukerMedGodeMuligheter.gtForBruker as GtForBrukerFunnet
+                    ),
+                    aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
+                        KontorTilordning(
+                            ungBrukerMedGodeMuligheter.fnr(),
+                            ungBrukerMedGodeMuligheter.gtKontor(),
+                            ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
                         ),
-                    )
+                        skjerming = HarSkjerming(true),
+                        registrant = System(Systemnavn.SKJERMING),
+                    ),
                 )
             )
         }
@@ -625,30 +627,29 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
                     brukerMedLandskodeOgFallback.fnr(),
                     HarSkjerming(true)
                 )
-            ) shouldBe Result.success(
-                EndringISkjermingResult(
-                    KontorEndringer(
-                        gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
-                            KontorTilordning(
-                                brukerMedLandskodeOgFallback.fnr(),
-                                brukerMedLandskodeOgFallback.gtKontor(),
-                                brukerMedLandskodeOgFallback.oppfolgingsperiodeId()
-                            ),
-                            HarSkjerming(true),
-                            brukerMedLandskodeOgFallback.gtForBruker as GtLandForBrukerFunnet
+            ) shouldBe EndringISkjermingSuccess(
+                KontorEndringer(
+                    gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
+                        KontorTilordning(
+                            brukerMedLandskodeOgFallback.fnr(),
+                            brukerMedLandskodeOgFallback.gtKontor(),
+                            brukerMedLandskodeOgFallback.oppfolgingsperiodeId()
                         ),
-                        aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
-                            KontorTilordning(
-                                brukerMedLandskodeOgFallback.fnr(),
-                                brukerMedLandskodeOgFallback.gtKontor(),
-                                brukerMedLandskodeOgFallback.oppfolgingsperiodeId()
-                            ),
-                            skjerming = HarSkjerming(true),
-                            registrant = System(Systemnavn.SKJERMING),
+                        HarSkjerming(true),
+                        brukerMedLandskodeOgFallback.gtForBruker as GtLandForBrukerFunnet
+                    ),
+                    aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
+                        KontorTilordning(
+                            brukerMedLandskodeOgFallback.fnr(),
+                            brukerMedLandskodeOgFallback.gtKontor(),
+                            brukerMedLandskodeOgFallback.oppfolgingsperiodeId()
                         ),
-                    )
+                        skjerming = HarSkjerming(true),
+                        registrant = System(Systemnavn.SKJERMING),
+                    ),
                 )
             )
+
         }
 
         it("skal ikke sette AO kontor men GT kontor til skjermet kontor når bruker blir skjermet også når bruker har landskode og norg svarer 404") {
@@ -658,8 +659,8 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
                     HarSkjerming(true)
                 )
             ).let {
-                it.isFailure shouldBe true
-                it.exceptionOrNull()?.message shouldBe "Skjermede brukere uten geografisk tilknytning eller med land som GT kan ikke tilordnes kontor: gt - 5050 type: Kommune"
+                it.shouldBeInstanceOf<EndringISkjermingBehandlingFeilet>()
+                it.exception.message shouldBe "Uventet feil ved håndtering av endring i skjerming: Skjermede brukere uten geografisk tilknytning eller med land som GT kan ikke tilordnes kontor: gt - 5050 type: Kommune"
             }
         }
 
@@ -669,7 +670,7 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
                     brukerMedLandskodeUtenFallback.fnr(),
                     HarSkjerming(true)
                 )
-            ) shouldBe Result.success(EndringISkjermingResult(
+            ) shouldBe EndringISkjermingSuccess(
                 KontorEndringer(
                     gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
                         KontorTilordning(
@@ -689,8 +690,8 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
                         skjerming = HarSkjerming(true),
                         registrant = System(Systemnavn.SKJERMING),
                     ),
-                ))
-            ) shouldBe Result.success(EndringISkjermingResult(
+                )
+            ) shouldBe EndringISkjermingSuccess(
                 KontorEndringer(
                     gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
                         KontorTilordning(
@@ -712,7 +713,6 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
                     ),
                 )
             )
-            )
         }
 
         it("skal sette GT-kontor og AO-kontor når bruker blir av-skjermet") {
@@ -721,63 +721,59 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
                     ungBrukerMedGodeMuligheter.fnr(),
                     HarSkjerming(false)
                 )
-            ) shouldBe Result.success(
-                EndringISkjermingResult(
-                    KontorEndringer(
-                        gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
-                            KontorTilordning(
-                                ungBrukerMedGodeMuligheter.fnr(),
-                                ungBrukerMedGodeMuligheter.gtKontor(),
-                                ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
-                            ),
-                            HarSkjerming(false),
-                            ungBrukerMedGodeMuligheter.gtForBruker as GtForBrukerFunnet
+            ) shouldBe EndringISkjermingSuccess(
+                KontorEndringer(
+                    gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
+                        KontorTilordning(
+                            ungBrukerMedGodeMuligheter.fnr(),
+                            ungBrukerMedGodeMuligheter.gtKontor(),
+                            ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
                         ),
-                        aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
-                            KontorTilordning(
-                                ungBrukerMedGodeMuligheter.fnr(),
-                                ungBrukerMedGodeMuligheter.gtKontor(),
-                                ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
-                            ),
-                            skjerming = HarSkjerming(false),
-                            registrant = System(Systemnavn.SKJERMING),
+                        HarSkjerming(false),
+                        ungBrukerMedGodeMuligheter.gtForBruker as GtForBrukerFunnet
+                    ),
+                    aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
+                        KontorTilordning(
+                            ungBrukerMedGodeMuligheter.fnr(),
+                            ungBrukerMedGodeMuligheter.gtKontor(),
+                            ungBrukerMedGodeMuligheter.oppfolgingsperiodeId()
                         ),
-                    )
+                        skjerming = HarSkjerming(false),
+                        registrant = System(Systemnavn.SKJERMING),
+                    ),
                 )
             )
         }
 
-        it("skal ikke behandle brukere som ikke er under oppfølging") {
+        it("skal ikke opprette kontorendringer for brukere som ikke er under oppfølging") {
             gitt(brukerIkkeUnderOppfolging).handterEndringISkjermingStatus(
                 SkjermetStatusEndret(brukerIkkeUnderOppfolging.fnr(), HarSkjerming(true))
-            ) shouldBe Result.success(EndringISkjermingResult(KontorEndringer()))
+            ) shouldBe EndringISkjermingBrukerIkkeUnderOppfølging
         }
 
         it("skal sette hardkodet-fallback kontor (navit) på ao-kontor og gt-kontor hvis gt ikke finnes og fallback til arbeidsfordeling heller ikke finner kontor og skjerming er true") {
             gitt(brukerSomManglerGt).handterEndringISkjermingStatus(
                 SkjermetStatusEndret(brukerSomManglerGt.fnr(), HarSkjerming(true))
-            ) shouldBe Result.success(
-                EndringISkjermingResult(
-                    KontorEndringer(
-                        gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
-                            KontorTilordning(
-                                brukerSomManglerGt.fnr(),
-                                INGEN_GT_KONTOR_FALLBACK,
-                                brukerSomManglerGt.oppfolgingsperiodeId()
-                            ),
-                            HarSkjerming(true),
-                            brukerSomManglerGt.gtForBruker as GtForBrukerIkkeFunnet
+            ) shouldBe EndringISkjermingSuccess(
+                KontorEndringer(
+                    gtKontorEndret = GTKontorEndret.endretPgaSkjermingEndret(
+                        KontorTilordning(
+                            brukerSomManglerGt.fnr(),
+                            INGEN_GT_KONTOR_FALLBACK,
+                            brukerSomManglerGt.oppfolgingsperiodeId()
                         ),
-                        aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
-                            KontorTilordning(
-                                brukerSomManglerGt.fnr(),
-                                INGEN_GT_KONTOR_FALLBACK,
-                                brukerSomManglerGt.oppfolgingsperiodeId()
-                            ),
-                            skjerming = HarSkjerming(true),
-                            registrant = System(Systemnavn.SKJERMING),
+                        HarSkjerming(true),
+                        brukerSomManglerGt.gtForBruker as GtForBrukerIkkeFunnet
+                    ),
+                    aoKontorEndret = AOKontorEndretPgaSkjermingEndret(
+                        KontorTilordning(
+                            brukerSomManglerGt.fnr(),
+                            INGEN_GT_KONTOR_FALLBACK,
+                            brukerSomManglerGt.oppfolgingsperiodeId()
                         ),
-                    )
+                        skjerming = HarSkjerming(true),
+                        registrant = System(Systemnavn.SKJERMING),
+                    ),
                 )
             )
         }
@@ -930,12 +926,18 @@ class AutomatiskKontorRutingServiceTest : DescribeSpec({
             it("handterEndringISkjermingStatus - feil ved henting av adressebeskyttelse skal returnere feil") {
                 gitt(brukerMedFeilendeAdressebeskyttelse).handterEndringISkjermingStatus(
                     SkjermetStatusEndret(brukerMedFeilendeAdressebeskyttelse.fnr(), HarSkjerming(true))
-                ).isFailure shouldBe true
+                ).let {
+                    it.shouldBeInstanceOf<EndringISkjermingBehandlingFeilet>()
+                    it.exception.message shouldBe "Kunne ikke hente adressebeskyttelse ved endring i skjermingstatus: feil i adressebeskyttelse"
+                }
             }
             it("handterEndringISkjermingStatus - feil ved henting av gt skal returnere feil") {
                 gitt(brukerMedFeilendeKontorForGt).handterEndringISkjermingStatus(
                     SkjermetStatusEndret(brukerMedFeilendeKontorForGt.fnr(), HarSkjerming(true))
-                ).isFailure shouldBe true
+                ).let {
+                    it.shouldBeInstanceOf<EndringISkjermingBehandlingFeilet>()
+                    it.exception.message shouldBe "Kunne ikke håndtere endring i skjerming pga feil ved henting av gt-kontor: Feil i gt-kontor oppslag"
+                }
             }
         }
 


### PR DESCRIPTION
Tidligere returnerte funksjonen `handterEndringISkjermingStatus` i `AutomatiskKontorRutingService` følgende når man mottok melding om at person uten oppfølgingsperiode var skjermet: `Result.success(EndringISkjermingResult(KontorEndringer()))`. Altså objekt av `KontorEndringer` som hadde tomt innhold.

Problemet var at funksjonen `handterEndringISKjermetStatus` i `SkjermingProcessor` kastet feil når man fikk et objekt av `KontorEndringer` som ikke inneholdt en endring for AO-kontor:

```
if (endringResult.endringer.aoKontorEndret != null) {
    val record = endringResult.endringer.aoKontorEndret.toOppfolgingEndretTilordningMeldingRecord()
    Forward(record)
} else {
    log.error("Fikk melding om endring av skjermet men klarte ikke å sette nytt kontor: $endringResult")
    Retry("Fikk melding om endring av skjermet men klarte ikke å sette nytt kontor: $endringResult")
}
```